### PR TITLE
'YouTrackConfigurationForm' object has no attribute 'cleaned_data'

### DIFF
--- a/sentry_youtrack/forms.py
+++ b/sentry_youtrack/forms.py
@@ -209,6 +209,8 @@ class YouTrackConfigurationForm(forms.Form):
             del self.fields['default_tags']
             del self.fields['ignore_fields']
 
+        if self._errors is None:
+            self.full_clean()
         for field, error in self.client_errors.iteritems():
             self._errors[field] = [error]
 

--- a/sentry_youtrack/forms.py
+++ b/sentry_youtrack/forms.py
@@ -173,7 +173,6 @@ class YouTrackConfigurationForm(forms.Form):
         super(YouTrackConfigurationForm, self).__init__(*args, **kwargs)
 
         self.client_errors = {}
-        self._errors = {}
         client = None
         initial = kwargs.get("initial")
 


### PR DESCRIPTION
fixes SENTRY-1SD

think this was breaking because of https://github.com/django/django/blob/stable/1.6.x/django/forms/forms.py#L120

@getsentry/infrastructure

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-youtrack/2)

<!-- Reviewable:end -->
