### PR TITLE
TypeError: 'NoneType' object is not iterable

### DIFF
--- a/sentry_youtrack/configuration.py
+++ b/sentry_youtrack/configuration.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 from requests.exceptions import ConnectionError, HTTPError, SSLError
 from sentry.exceptions import PluginError
 from django.utils.translation import ugettext_lazy as _

--- a/sentry_youtrack/configuration.py
+++ b/sentry_youtrack/configuration.py
@@ -140,7 +140,7 @@ class YouTrackConfiguration(object):
             else:
                 self.client_errors['project'] = self.error_message['project_unknown']
 
-    def get_projects(self, client):
+    def get_projects(self, client, project_id):
         try:
             return list(client.get_projects())
         except (HTTPError, ConnectionError) as e:

--- a/sentry_youtrack/youtrack.py
+++ b/sentry_youtrack/youtrack.py
@@ -156,14 +156,22 @@ class YouTrackClient(object):
     def get_projects(self):
         url = self.url + self.PROJECTS_URL
         response = self.request(url, method='get')
-        for project in BeautifulSoup(response.text, 'xml').projects:
+        data = BeautifulSoup(response.text, 'xml')
+        for project in data.projectShorts:
             yield {'id': project['shortName'], 'name': project['name']}
 
     def get_priorities(self):
-        return self._get_custom_field_values('bundle', 'Priorities')
+        try:
+            return self._get_custom_field_values('bundle', 'Priorities')
+        except:
+            return self._get_custom_field_values('bundle', u'Приоритеты')
 
     def get_issue_types(self):
-        return self._get_custom_field_values('bundle', 'Types')
+        try:
+            return self._get_custom_field_values('bundle', 'Types')
+        except:
+            return self._get_custom_field_values('bundle', u'Типы')
+
 
     def get_project_issues(self, project_id, query=None, offset=0, limit=15):
         url = self.url + self.ISSUES_URL.replace('<project_id>', project_id)

--- a/sentry_youtrack/youtrack.py
+++ b/sentry_youtrack/youtrack.py
@@ -163,7 +163,7 @@ class YouTrackClient(object):
 
     def get_priorities(self):
         try:
-            return self._get_custom_field_values('bundle', 'Priorities2')
+            return self._get_custom_field_values('bundle', 'Priorities')
         except:
             return self._get_custom_field_values('bundle', u'Приоритеты')
 

--- a/sentry_youtrack/youtrack.py
+++ b/sentry_youtrack/youtrack.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 import requests
 import logging
 from bs4 import BeautifulSoup
@@ -162,7 +163,7 @@ class YouTrackClient(object):
 
     def get_priorities(self):
         try:
-            return self._get_custom_field_values('bundle', 'Priorities')
+            return self._get_custom_field_values('bundle', 'Priorities2')
         except:
             return self._get_custom_field_values('bundle', u'Приоритеты')
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     license='BSD',
     packages=find_packages(),
     install_requires=[
-        'beautifulsoup4>=4.5.1',
+        'beautifulsoup4',
     ],
     include_package_data=True,
     zip_safe=False,
@@ -65,7 +65,7 @@ setup(
     },
     tests_require=[
         'pytest',
-        'vcrpy>=1.7.3',
-        'sentry>=8.0.0',
+        'vcrpy',
+        'sentry>=9.1.0',
     ]
 )

--- a/tests/cassettes/test_get_project_name.yaml
+++ b/tests/cassettes/test_get_project_name.yaml
@@ -8,9 +8,7 @@ interactions:
     uri: https://youtrack.myjetbrains.com/rest/admin/project/myproject
   response:
     body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><project
-        name="My project" id="myproject" archived="false" lead="root" assigneesUrl="https://youtrack.myjetbrains.com/rest/admin/project/myproject/assignee"
-        subsystemsUrl="https://youtrack.myjetbrains.com/rest/admin/project/myproject/subsystem"
-        buildsUrl="https://youtrack.myjetbrains.com/rest/admin/project/myproject/build" versionsUrl="https://youtrack.myjetbrains.com/rest/admin/project/myproject/version"/>'}
+        name="My project" id="myproject" archived="false" lead="root"/>'}
     headers:
       access-control-expose-headers: [Location]
       cache-control: ['no-cache, no-store, no-transform, must-revalidate']

--- a/tests/cassettes/test_get_projects.yaml
+++ b/tests/cassettes/test_get_projects.yaml
@@ -7,8 +7,8 @@ interactions:
     method: GET
     uri: https://youtrack.myjetbrains.com/rest/project/all
   response:
-    body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><projects><project
-        name="My project" shortName="myproject"/><project name="Test project" shortName="testproject"/></projects>'}
+    body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><projectShorts><project
+        name="My project" shortName="myproject"/><project name="Test project" shortName="testproject"/></projectShorts>'}
     headers:
       access-control-expose-headers: [Location]
       cache-control: ['no-cache, no-store, no-transform, must-revalidate']

--- a/tests/cassettes/yt_config.yaml
+++ b/tests/cassettes/yt_config.yaml
@@ -44,8 +44,8 @@ interactions:
     method: GET
     uri: https://youtrack.myjetbrains.com/rest/project/all
   response:
-    body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><projects><project
-        name="My project" shortName="myproject"/><project name="Test project" shortName="testproject"/></projects>'}
+    body: {string: !!python/unicode '<?xml version="1.0" encoding="UTF-8" standalone="yes"?><projectShorts><project
+        name="My project" shortName="myproject"/><project name="Test project" shortName="testproject"/></projectShorts>'}
     headers:
       access-control-expose-headers: [Location]
       cache-control: ['no-cache, no-store, no-transform, must-revalidate']


### PR DESCRIPTION
Exceptions:

```
TypeError: 'NoneType' object is not iterable
(2 additional frame(s) were not displayed)
...
  File "sentry/api/base.py", line 90, in handle_exception
    response = super(Endpoint, self).handle_exception(exc)
  File "sentry/api/base.py", line 190, in dispatch
    response = handler(request, *args, **kwargs)
  File "sentry/api/endpoints/project_plugin_details.py", line 129, in put
    initial=request.DATA,
```

```
TypeError: 'NoneType' object is not iterable
(6 additional frame(s) were not displayed)
...
  File "sentry/api/endpoints/project_plugin_details.py", line 185, in put
    context = serialize(plugin, request.user, PluginWithConfigSerializer(project))
  File "sentry/api/serializers/base.py", line 17, in serialize
    return serialize([objects], user=user, serializer=serializer, **kwargs)[0]
  File "sentry/api/serializers/base.py", line 38, in serialize
    return [serializer(o, attrs=attrs.get(o, {}), user=user, **kwargs) for o in objects]
  File "sentry/api/serializers/base.py", line 53, in __call__
    return self.serialize(obj, attrs, user, **kwargs)
  File "sentry/api/serializers/models/plugin.py", line 86, in serialize
    for c in obj.get_config(project=self.project, user=user, add_additial_fields=True)
```

These errors associated with changes in the data schema YouTrack, model Projects. Before the change was: 
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<projects></projects>
``` 
In version 2019.1 it became: 
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<projectShorts></projectShorts>
```
The plug-in has functions for obtaining pre-arranged enumerations, but depending on the installation and its localization, they have different names. For example, in the installation en-en 'Types', and in the installation ru-ru 'Типы'